### PR TITLE
Return the best submit (not: the worst) in result summary

### DIFF
--- a/app/models/contest_problem.rb
+++ b/app/models/contest_problem.rb
@@ -16,7 +16,7 @@ class ContestProblem < ApplicationRecord
   def results(owner_id)
     results = []
     contest.contest_participations.where(contest_owner_id: owner_id).find_each do |participation|
-      submit = submits.order(status: :desc, created_at: :desc).find_by(author: participation.user)
+      submit = submits.order(status: :asc, created_at: :desc).find_by(author: participation.user)
       results.push(submit) if submit
     end
     results


### PR DESCRIPTION
GraphQL query seems to return the worst submit in problem
summary (e.g. `:err` instead of `:ok`).