### PR TITLE
Sort Submit#contest_solutions in predictable order

### DIFF
--- a/app/models/contest_problem.rb
+++ b/app/models/contest_problem.rb
@@ -12,7 +12,7 @@ class ContestProblem < ApplicationRecord
   validates :base_points, presence: true
   validates :soft_deadline, presence: true
   validates :hard_deadline, presence: true
-  validates :required, presence: true
+  validates :required, inclusion: { in: [true, false] }
 
   # get all the submits for this problem that can be viewed by this owner
   # only one (newest with status OK) submit is retrieved per participant

--- a/app/models/submit.rb
+++ b/app/models/submit.rb
@@ -36,6 +36,7 @@ class Submit < ApplicationRecord
              .map { |problem, problem_submits| { problem: problem, attempts: attempts.call(problem_submits) } }
     end
     Submit.contest(contest_id, contest_owner_id).eager_load(:contest_problem, :author)
+          .order('contest_problems.required DESC', 'contest_problems.created_at')
           .group_by(&:author)
           .map { |author, submits| { user: author, solutions: solutions.call(submits) } }
   end

--- a/spec/models/submit_spec.rb
+++ b/spec/models/submit_spec.rb
@@ -114,5 +114,28 @@ describe Submit do
       expect(contest_solutions[0][:solutions][0][:attempts]).to eq(1)
       expect(contest_solutions[1][:solutions][0][:attempts]).to eq(1)
     end
+
+    it 'sorts problems in order: required then optional, created_at' do
+      later_optional_problem = create(:contest_problem, contest: contest, required: false, created_at: 2.days.ago)
+      create(:submit, author: participant, contest_problem: later_optional_problem)
+
+      earlier_required_problem = create(:contest_problem, contest: contest, required: true, created_at: 3.days.ago)
+      create(:submit, author: participant, contest_problem: earlier_required_problem)
+
+      earlier_optional_problem = create(:contest_problem, contest: contest, required: false, created_at: 4.days.ago)
+      create(:submit, author: participant, contest_problem: earlier_optional_problem)
+
+      later_required_problem = create(:contest_problem, contest: contest, required: true, created_at: 1.day.ago)
+      create(:submit, author: participant, contest_problem: later_required_problem)
+
+      expect(contest_solutions).to eq([
+                                        { user: participant, solutions: [
+                                          { problem: earlier_required_problem, attempts: 1 },
+                                          { problem: later_required_problem, attempts: 1 },
+                                          { problem: earlier_optional_problem, attempts: 1 },
+                                          { problem: later_optional_problem, attempts: 1 }
+                                        ] }
+                                      ])
+    end
   end
 end


### PR DESCRIPTION
Attempted problems are sorted in order: required first, then chronologically
by problem creation date.